### PR TITLE
feat: Add ScrollableMediaCanvas widget

### DIFF
--- a/example/lib/scrollable_media_canvas_demo.dart
+++ b/example/lib/scrollable_media_canvas_demo.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+import 'package:scribble/scribble.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'ScrollableMediaCanvas Demo',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const ScrollableMediaCanvasDemo(),
+    );
+  }
+}
+
+class ScrollableMediaCanvasDemo extends StatefulWidget {
+  const ScrollableMediaCanvasDemo({super.key});
+
+  @override
+  State<ScrollableMediaCanvasDemo> createState() =>
+      _ScrollableMediaCanvasDemoState();
+}
+
+class _ScrollableMediaCanvasDemoState extends State<ScrollableMediaCanvasDemo> {
+  late final MediaCanvasNotifier _notifier;
+
+  @override
+  void initState() {
+    super.initState();
+    _notifier = MediaCanvasNotifier(pages: []);
+    _loadPages();
+  }
+
+  Future<void> _loadPages() async {
+    // Page 1: Sketch only
+    _notifier.addPage(
+      const MediaPage(
+        sketch: Sketch(lines: []),
+        size: Size(400, 600),
+      ),
+    );
+
+    // Page 2: PDF
+    final pdfPath = await _loadPdf();
+    if (pdfPath != null) {
+      _notifier.addPage(
+        MediaPage(
+          sketch: const Sketch(lines: []),
+          size: const Size(400, 600),
+          mediaType: MediaType.pdf,
+          pdfPath: pdfPath,
+        ),
+      );
+    }
+    setState(() {});
+  }
+
+  Future<String?> _loadPdf() async {
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      final file = File('${dir.path}/sample.pdf');
+      if (await file.exists()) {
+        return file.path;
+      }
+      final response = await http.get(Uri.parse('https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf'));
+      await file.writeAsBytes(response.bodyBytes);
+      return file.path;
+    } catch (e) {
+      print('Failed to load PDF: $e');
+      return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('ScrollableMediaCanvas Demo'),
+      ),
+      body: ScrollableMediaCanvas(
+        notifier: _notifier,
+        showRowLines: true,
+      ),
+    );
+  }
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,6 +12,9 @@ dependencies:
   scribble:
     path: ..
   value_notifier_tools: ^0.1.2
+  http: ^1.2.1
+  path_provider: ^2.1.3
+  flutter_pdfview: ^1.3.2
 
 dev_dependencies:
   flutter_test:

--- a/lib/scribble.dart
+++ b/lib/scribble.dart
@@ -9,3 +9,6 @@ export 'package:scribble/src/view/scrollable_notebook_canvas.dart';
 export 'package:scribble/src/view/state/scribble.state.dart';
 export 'package:scribble/src/view/theme/scribble_theme.dart';
 export 'package:scribble/src/view/theme/scribble_theme_provider.dart';
+export 'package:scribble/src/view/scrollable_media_canvas.dart';
+export 'package:scribble/src/view/notifier/media_canvas_notifier.dart';
+export 'package:scribble/src/domain/model/page/media_page.dart';

--- a/lib/src/domain/model/page/media_page.dart
+++ b/lib/src/domain/model/page/media_page.dart
@@ -1,0 +1,25 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:scribble/scribble.dart';
+
+enum MediaType {
+  image,
+  pdf,
+  sketch,
+}
+
+class MediaPage {
+  const MediaPage({
+    required this.sketch,
+    required this.size,
+    this.mediaType = MediaType.sketch,
+    this.imageData,
+    this.pdfPath,
+  });
+
+  final Sketch sketch;
+  final Size size;
+  final MediaType mediaType;
+  final Uint8List? imageData;
+  final String? pdfPath;
+}

--- a/lib/src/view/notifier/media_canvas_notifier.dart
+++ b/lib/src/view/notifier/media_canvas_notifier.dart
@@ -7,7 +7,9 @@ class MediaCanvasNotifier extends ValueNotifier<ScribbleState> {
     List<MediaPage>? pages,
   })  : _pages = pages ?? [],
         super(ScribbleState.drawing(
-          sketch: pages?.first.sketch ?? const Sketch(lines: []),
+          sketch: (pages != null && pages.isNotEmpty)
+              ? pages.first.sketch
+              : const Sketch(lines: []),
         ));
 
   final List<MediaPage> _pages;

--- a/lib/src/view/notifier/media_canvas_notifier.dart
+++ b/lib/src/view/notifier/media_canvas_notifier.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/widgets.dart';
+import 'package:scribble/scribble.dart';
+import 'package:scribble/src/domain/model/page/media_page.dart';
+
+class MediaCanvasNotifier extends ValueNotifier<ScribbleState> {
+  MediaCanvasNotifier({
+    List<MediaPage>? pages,
+  })  : _pages = pages ?? [],
+        super(ScribbleState.drawing(
+          sketch: pages?.first.sketch ?? const Sketch(lines: []),
+        ));
+
+  final List<MediaPage> _pages;
+  int _currentPageIndex = 0;
+
+  List<MediaPage> get pages => _pages;
+
+  int get currentPageIndex => _currentPageIndex;
+
+  ScribbleNotifier? _currentScribbleNotifier;
+
+  void setScribbleNotifier(ScribbleNotifier notifier) {
+    _currentScribbleNotifier = notifier;
+  }
+
+  void addPage(MediaPage page) {
+    _pages.add(page);
+    notifyListeners();
+  }
+
+  void removePage(int index) {
+    if (index >= 0 && index < _pages.length) {
+      _pages.removeAt(index);
+      if (_currentPageIndex >= _pages.length) {
+        _currentPageIndex = _pages.length - 1;
+      }
+      notifyListeners();
+    }
+  }
+
+  void setCurrentPage(int index) {
+    if (index >= 0 && index < _pages.length) {
+      _currentPageIndex = index;
+      final newSketch = _pages[index].sketch;
+      _currentScribbleNotifier?.setSketch(sketch: newSketch);
+      notifyListeners();
+    }
+  }
+}

--- a/lib/src/view/scrollable_media_canvas.dart
+++ b/lib/src/view/scrollable_media_canvas.dart
@@ -62,8 +62,12 @@ class _ScrollableMediaCanvasState extends State<ScrollableMediaCanvas> {
                       height: page.size.height,
                     )
                   else if (page.mediaType == MediaType.pdf && page.pdfPath != null)
-                    PDFView(
-                      filePath: page.pdfPath,
+                    SizedBox(
+                      width: page.size.width,
+                      height: page.size.height,
+                      child: PDFView(
+                        filePath: page.pdfPath,
+                      ),
                     ),
                   SizedBox(
                     width: page.size.width,

--- a/lib/src/view/scrollable_media_canvas.dart
+++ b/lib/src/view/scrollable_media_canvas.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_pdfview/flutter_pdfview.dart';
+import 'package:scribble/scribble.dart';
+import 'package:scribble/src/domain/model/page/media_page.dart';
+import 'package:scribble/src/view/notifier/media_canvas_notifier.dart';
+
+class ScrollableMediaCanvas extends StatefulWidget {
+  const ScrollableMediaCanvas({
+    required this.notifier,
+    this.showRowLines = false,
+    this.rowLineSpacing = 24.0,
+    this.rowLineColor = Colors.grey,
+    this.rowLineWidth = 1.0,
+    super.key,
+  });
+
+  final MediaCanvasNotifier notifier;
+  final bool showRowLines;
+  final double rowLineSpacing;
+  final Color rowLineColor;
+  final double rowLineWidth;
+
+  @override
+  State<ScrollableMediaCanvas> createState() => _ScrollableMediaCanvasState();
+}
+
+class _ScrollableMediaCanvasState extends State<ScrollableMediaCanvas> {
+  late final ScribbleNotifier _scribbleNotifier;
+
+  @override
+  void initState() {
+    super.initState();
+    _scribbleNotifier = ScribbleNotifier(
+      sketch: widget.notifier.pages.isNotEmpty
+          ? widget.notifier.pages[widget.notifier.currentPageIndex].sketch
+          : null,
+    );
+    widget.notifier.setScribbleNotifier(_scribbleNotifier);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: widget.notifier,
+      builder: (context, _) {
+        return ListView.builder(
+          itemCount: widget.notifier.pages.length,
+          itemBuilder: (context, index) {
+            final page = widget.notifier.pages[index];
+            final isSelected = index == widget.notifier.currentPageIndex;
+            return GestureDetector(
+              onTap: () {
+                widget.notifier.setCurrentPage(index);
+              },
+              child: Stack(
+                children: [
+                  if (page.mediaType == MediaType.image && page.imageData != null)
+                    Image.memory(
+                      page.imageData!,
+                      fit: BoxFit.cover,
+                      width: page.size.width,
+                      height: page.size.height,
+                    )
+                  else if (page.mediaType == MediaType.pdf && page.pdfPath != null)
+                    PDFView(
+                      filePath: page.pdfPath,
+                    ),
+                  SizedBox(
+                    width: page.size.width,
+                    height: page.size.height,
+                    child: CustomPaint(
+                      painter: widget.showRowLines
+                          ? _RowLinePainter(
+                              rowLineSpacing: widget.rowLineSpacing,
+                              lineColor: widget.rowLineColor,
+                              lineWidth: widget.rowLineWidth,
+                            )
+                          : null,
+                      child: isSelected
+                          ? Scribble(
+                              notifier: _scribbleNotifier,
+                            )
+                          : AbsorbPointer(
+                              child: Scribble(
+                                notifier: ScribbleNotifier(
+                                  sketch: page.sketch,
+                                ),
+                              ),
+                            ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _RowLinePainter extends CustomPainter {
+  _RowLinePainter({
+    required this.rowLineSpacing,
+    required this.lineColor,
+    required this.lineWidth,
+  });
+
+  final double rowLineSpacing;
+  final Color lineColor;
+  final double lineWidth;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = lineColor
+      ..strokeWidth = lineWidth;
+
+    for (double y = rowLineSpacing; y < size.height; y += rowLineSpacing) {
+      canvas.drawLine(Offset(0, y), Offset(size.width, y), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_RowLinePainter oldDelegate) {
+    return oldDelegate.rowLineSpacing != rowLineSpacing ||
+        oldDelegate.lineColor != lineColor ||
+        oldDelegate.lineWidth != lineWidth;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   perfect_freehand: ^2.3.2
   simpli: ^0.1.1
   value_notifier_tools: ^0.1.2
+  flutter_pdfview: ^1.3.2
+  path_provider: ^2.1.3
+  http: ^1.2.1
 
 dev_dependencies:
   build_runner: ^2.4.9


### PR DESCRIPTION
This change introduces a new `ScrollableMediaCanvas` widget.

This widget provides a scrollable view of multiple pages, where each page can contain a background (image or PDF) and a drawable sketch overlay.

It includes:
- A new `ScrollableMediaCanvas` widget.
- A `MediaPage` data model to represent a page's content.
- A `MediaCanvasNotifier` for state management.
- An example screen to demonstrate the usage of the new widget.
- Simple, optional row lines.

This new widget is simpler than the existing `ScrollableNotebookCanvas` and does not include complex features like line numbers, row controls, or writing constraints.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [ ] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [ ] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
